### PR TITLE
[Fix] Refresh 발급 로직 및 접근 권한 수정, 로그인 예외처리, Refresh 요청 스펙 변경

### DIFF
--- a/src/main/java/com/miniproject/domain/refresh/exception/RefreshTokenException.java
+++ b/src/main/java/com/miniproject/domain/refresh/exception/RefreshTokenException.java
@@ -1,0 +1,11 @@
+package com.miniproject.domain.refresh.exception;
+
+import com.miniproject.global.exception.ApplicationException;
+import com.miniproject.global.exception.ErrorCode;
+
+public class RefreshTokenException extends ApplicationException {
+    private static ErrorCode errorCode = ErrorCode.REFRESH_TOKEN_EXCEPTION;
+    public RefreshTokenException() {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/miniproject/domain/refresh/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/miniproject/domain/refresh/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,11 @@
+package com.miniproject.domain.refresh.exception;
+
+import com.miniproject.global.exception.ApplicationException;
+import com.miniproject.global.exception.ErrorCode;
+
+public class RefreshTokenNotFoundException extends ApplicationException {
+    private static ErrorCode errorCode = ErrorCode.NOT_FOUND_REFRESH_TOKEN;
+    public RefreshTokenNotFoundException() {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/miniproject/global/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/miniproject/global/config/JwtAuthenticationEntryPoint.java
@@ -9,7 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -33,10 +33,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             log.error("Request Uri : {}", request.getRequestURI());
             errorMessage = "토큰 기간이 만료되었습니다. ";
 
-        } else if (authException instanceof BadCredentialsException) {
-            log.error("BadCredentialsException", authException);
+        } else if (authException instanceof InsufficientAuthenticationException) {
+            log.error("InsufficientAuthenticationException", authException);
             log.error("Request Uri : {}", request.getRequestURI());
-            errorMessage = "비밀번호가 맞지 않습니다. ";
+            errorMessage = "아이디 또는 비밀번호가 맞지 않습니다. ";
         } else {
             errorMessage = "유효하지 않은 입력입니다. ";
         }

--- a/src/main/java/com/miniproject/global/exception/ErrorCode.java
+++ b/src/main/java/com/miniproject/global/exception/ErrorCode.java
@@ -9,6 +9,10 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
     MEMBER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 접근입니다."),
+
+    //리프레시토큰
+    REFRESH_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 RefreshToken 입니다. "),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "리프레시 토큰이 존재하지 않습니다."),
     //숙소
     ACCOOMMODATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 숙소입니다."),
 

--- a/src/main/java/com/miniproject/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/com/miniproject/global/exception/GlobalExceptionRestAdvice.java
@@ -1,11 +1,13 @@
 package com.miniproject.global.exception;
 
 import com.miniproject.domain.member.exception.MemberUnAuthorizedException;
+import com.miniproject.global.jwt.exception.BadTokenException;
 import com.miniproject.global.util.ResponseDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,6 +21,14 @@ public class GlobalExceptionRestAdvice {
         return ResponseEntity
             .status(e.getErrorCode().getHttpStatus())
             .body(ResponseDTO.res(e.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDTO<Object>> applicationException(BadTokenException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDTO.res("적절치 않은 RefreshToken 입니다."));
     }
 
     @ExceptionHandler

--- a/src/main/java/com/miniproject/global/jwt/JwtProvider.java
+++ b/src/main/java/com/miniproject/global/jwt/JwtProvider.java
@@ -47,6 +47,17 @@ public class JwtProvider {
                 .compact();
     }
 
+    public String reCreateToken(JwtPayload jwtPayload, long expiration) {
+        Date now = new Date();
+        return Jwts.builder()
+                .claim(USER_KEY, Objects.requireNonNull(jwtPayload.email()))
+                .issuer(issuer)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
     public JwtPayload verifyToken(String jwtToken) {
         try {
             Jws<Claims> claimsJws = Jwts.parser().verifyWith(secretKey).build()

--- a/src/main/java/com/miniproject/global/jwt/api/RefreshTokenRequest.java
+++ b/src/main/java/com/miniproject/global/jwt/api/RefreshTokenRequest.java
@@ -3,7 +3,6 @@ package com.miniproject.global.jwt.api;
 import jakarta.validation.constraints.NotBlank;
 
 public record RefreshTokenRequest(
-        @NotBlank String accessToken,
         @NotBlank String refreshToken
 ) {
 }

--- a/src/main/java/com/miniproject/global/jwt/service/JwtService.java
+++ b/src/main/java/com/miniproject/global/jwt/service/JwtService.java
@@ -78,7 +78,7 @@ public class JwtService {
         }
 
         //새로운 액세스 토큰 발급
-        String refreshedAccessToken = jwtProvider.createToken(jwtPayload, accessExpiration);
+        String refreshedAccessToken = jwtProvider.reCreateToken(jwtPayload, accessExpiration);
         return new JwtPair(refreshedAccessToken, request.refreshToken());
     }
 

--- a/src/main/java/com/miniproject/global/jwt/service/JwtService.java
+++ b/src/main/java/com/miniproject/global/jwt/service/JwtService.java
@@ -73,13 +73,11 @@ public class JwtService {
         //DB에 저장된 member의 리프레시 토큰을 꺼내옴
         var refreshToken = refreshTokenRepository.findRefreshTokenByMemberEmail(jwtPayload.email());
 
-        //같은지 비교
-
-        String savedTokenInfo = refreshToken.getToken();
-
-        if (savedTokenInfo == null) {
+        if (refreshToken.getToken() == null) {
             throw new RefreshTokenNotFoundException();
         }
+        String savedTokenInfo = refreshToken.getToken();
+
         if (!isAcceptable(savedTokenInfo, request.refreshToken())) {
             throw new RefreshTokenException();
         }

--- a/src/main/java/com/miniproject/global/security/SecurityFilterConfig.java
+++ b/src/main/java/com/miniproject/global/security/SecurityFilterConfig.java
@@ -44,7 +44,8 @@ public class SecurityFilterConfig {
         http.authorizeHttpRequests(request ->
                 request
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/accommodations"), new AntPathRequestMatcher("/api/v1/accommodations/**")).permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/api/v1/members/join"), new AntPathRequestMatcher("/api/v1/members/login", "/api/v1/refresh")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/api/v1/members/join"), new AntPathRequestMatcher("/api/v1/members/login")
+                        ,new AntPathRequestMatcher("/api/v1/refresh")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/rooms"), new AntPathRequestMatcher("/api/v1/rooms/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/rooms/{room_id}/orders")).authenticated()
                         .anyRequest().authenticated()

--- a/src/main/java/com/miniproject/global/security/login/CustomLoginProvider.java
+++ b/src/main/java/com/miniproject/global/security/login/CustomLoginProvider.java
@@ -21,15 +21,17 @@ public class CustomLoginProvider implements AuthenticationProvider {
 
 
     @Override
-    public Authentication authenticate(Authentication authentication)
-            throws AuthenticationException {
+    public Authentication authenticate(Authentication authentication) {
+
+
         String username = (String) authentication.getPrincipal();
         String password = (String) authentication.getCredentials();
 
         AccountContext accountContext = (AccountContext) userDetailsService
                 .loadUserByUsername(username);
+
         if (!passwordEncoder.matches(password, accountContext.getPassword())) {
-            throw new BadCredentialsException("Login Fail");
+            throw new BadCredentialsException("비밀번호가 맞지 않습니다.");
         }
         return CustomLoginToken.authenticate(username, accountContext.getAuthorities());
     }
@@ -39,4 +41,5 @@ public class CustomLoginProvider implements AuthenticationProvider {
         return CustomLoginToken.class.isAssignableFrom(authentication);
     }
 }
+
 

--- a/src/main/java/com/miniproject/global/security/login/CustomUserDetailsService.java
+++ b/src/main/java/com/miniproject/global/security/login/CustomUserDetailsService.java
@@ -22,9 +22,8 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(username).orElseThrow(() -> new IllegalArgumentException("member not found"));
-
+    public UserDetails loadUserByUsername(String username){
+        Member member = memberRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException(""));
         return new AccountContext(member.getEmail(), member.getPassword(),
                 Set.of(new SimpleGrantedAuthority("ROLE_USER")));
     }

--- a/src/test/java/com/miniproject/global/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/miniproject/global/jwt/service/JwtServiceTest.java
@@ -113,7 +113,7 @@ class JwtServiceTest {
     @Nested
     class Context_refreshAccessToken {
 
-        @DisplayName("accessToken, refreshToken이 정확히 일치해야 재발급 받을 수 있다.")
+        @DisplayName("DB에 저장된 내용과 refreshToken이 정확히 일치해야 재발급 받을 수 있다.")
         @Test
         void memberId_accessToken_refreshToken_isEquals_willSuccess() {
 
@@ -124,7 +124,7 @@ class JwtServiceTest {
 
             // when
             JwtPair refreshedJwtPair = jwtService.refreshAccessToken(
-                    new RefreshTokenRequest(tokenPair.accessToken(), tokenPair.refreshToken()));
+                    new RefreshTokenRequest(tokenPair.refreshToken()));
 
             // then
             assertEquals(refreshedJwtPair.refreshToken(), tokenPair.refreshToken());
@@ -143,7 +143,7 @@ class JwtServiceTest {
 
             // when then
             assertThrows(TokenExpiredException.class, () -> jwtService.refreshAccessToken(
-                    new RefreshTokenRequest(tokenPair.accessToken(), tokenPair.refreshToken())));
+                    new RefreshTokenRequest(tokenPair.refreshToken())));
         }
 
 //        @DisplayName("가장 최근에 발급된 accessToken이 아니면 실패한다.")


### PR DESCRIPTION
# 내용
- api/v1/refresh 에 인증된 사용자만 접근이 가능했던 이슈를 해결했습니다.
- Refresh 토큰을 통해 AccessToken을 재발급 받는 과정에서 재발급 된 토큰이 기존 AccessToken와 만료 기간이 똑같던 오류를 수정했습니다.
- 로그인 과정에서 아이디 또는 비밀번호가 다를 때, 예외처리가 제대로 작동하지 않던 오류를 수정했습니다.
- RefreshToken을 통해 AccessToken을 재발급 받을 때, AccessToken을 body로 같이 받았었는데 RefreshToken만 검증을 하고 AccessToken은 검증을 하지 않았던 문제를 RefreshTokenRequest에서 RefreshToken만 받도록 수정했습니다.
- RefreshToken을 검증할 때 토큰이 만료된 경우, 토큰 형식이 아닌 경우, DB에 토큰이 없는 경우에 예외를 발생하도록 수정했습니다.
