### PR TITLE
JWT 리프레시토큰 리팩토링

### DIFF
--- a/src/main/java/com/miniproject/domain/member/entity/Member.java
+++ b/src/main/java/com/miniproject/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.miniproject.domain.member.entity;
 
+import com.miniproject.domain.basket.entity.Basket;
 import com.miniproject.domain.orders.entity.Orders;
 import com.miniproject.domain.wish.entity.Wish;
 import jakarta.persistence.*;
@@ -19,6 +20,10 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Orders> orders = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Basket> baskets = new ArrayList<>();
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,7 +49,6 @@ public class Member {
         this.phoneNumber = phoneNumber;
         this.likes = likes;
         this.orders = orders;
-
     }
 
 }

--- a/src/main/java/com/miniproject/domain/member/entity/Member.java
+++ b/src/main/java/com/miniproject/domain/member/entity/Member.java
@@ -15,16 +15,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    List<Wish> likes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    List<Orders> orders = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    List<Basket> baskets = new ArrayList<>();
-
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -37,7 +27,14 @@ public class Member {
 
     private String phoneNumber;
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Wish> likes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Orders> orders = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Basket> baskets = new ArrayList<>();
 
     @Builder
     public Member(String email, String nickname, String password, String phoneNumber,
@@ -49,5 +46,4 @@ public class Member {
         this.likes = likes;
         this.orders = orders;
     }
-
 }

--- a/src/main/java/com/miniproject/domain/member/entity/Member.java
+++ b/src/main/java/com/miniproject/domain/member/entity/Member.java
@@ -40,9 +40,8 @@ public class Member {
 
 
     @Builder
-    public Member(Long id, String email, String nickname, String password, String phoneNumber,
+    public Member(String email, String nickname, String password, String phoneNumber,
                   List<Wish> likes, List<Orders> orders) {
-        this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.password = password;

--- a/src/main/java/com/miniproject/domain/member/service/MemberService.java
+++ b/src/main/java/com/miniproject/domain/member/service/MemberService.java
@@ -29,12 +29,14 @@ public class MemberService {
     public Long signUp(SignUpRequest request) {
         validateDuplicateMember(request.email());
 
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .nickname(request.nickname())
                 .phoneNumber(request.phoneNumber())
-                .build()).getId();
+                .build();
+
+        return memberRepository.save(member).getId();
     }
 
     public Member getMemberByLoginInfo(LoginInfo loginInfo){

--- a/src/main/java/com/miniproject/domain/member/service/MemberService.java
+++ b/src/main/java/com/miniproject/domain/member/service/MemberService.java
@@ -10,6 +10,7 @@ import com.miniproject.global.resolver.LoginInfo;
 import com.miniproject.global.resolver.SecurityContext;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -26,6 +27,7 @@ public class MemberService {
         this.jwtService = jwtService;
     }
 
+    @Transactional
     public Long signUp(SignUpRequest request) {
         validateDuplicateMember(request.email());
 
@@ -39,6 +41,7 @@ public class MemberService {
         return memberRepository.save(member).getId();
     }
 
+    @Transactional(readOnly = true)
     public Member getMemberByLoginInfo(LoginInfo loginInfo){
         return memberRepository.findByEmail(loginInfo.username())
             .orElseThrow(MemberNotFoundException::new);

--- a/src/main/java/com/miniproject/domain/orders/service/OrdersService.java
+++ b/src/main/java/com/miniproject/domain/orders/service/OrdersService.java
@@ -52,7 +52,7 @@ public class OrdersService {
     public Orders getOrders(Long orderId, Member member) {
         Orders orders = ordersRepository.findById(orderId)
             .orElseThrow(OrdersNotFoundException::new);
-        if (!member.getId().equals(orders.getMember().getId())) {
+        if (!member.getEmail().equals(orders.getMember().getEmail())) {
             throw new MemberUnAuthorizedException();
         }
         return orders;

--- a/src/main/java/com/miniproject/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/miniproject/domain/payment/service/PaymentService.java
@@ -93,7 +93,7 @@ public class PaymentService {
     public Payment getPaymentForException(Long paymentId, Member member) {
         Payment payment = paymentRepository.findById(paymentId)
             .orElseThrow(PaymentNotFoundException::new);
-        if(!member.getId().equals(payment.getOrders().getMember().getId())){
+        if(!member.getEmail().equals(payment.getOrders().getMember().getEmail())){
             throw new MemberUnAuthorizedException();
         }
         return payment;

--- a/src/main/java/com/miniproject/domain/refresh/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/miniproject/domain/refresh/repository/RefreshTokenRepository.java
@@ -1,10 +1,7 @@
 package com.miniproject.domain.refresh.repository;
 
 import com.miniproject.domain.refresh.entity.RefreshToken;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 
@@ -18,9 +15,5 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     void deleteRefreshTokenByMemberEmail(String memberEmail);
 
 
-    @Transactional
-    @Modifying
-    @Query("DELETE FROM RefreshToken r WHERE r.expiryDate < ?1")
-    void deleteAllExpiredSince(LocalDateTime now);
-
+    void deleteRefreshTokensByExpiryDateBefore(LocalDateTime expiryDate_date);
 }

--- a/src/main/java/com/miniproject/domain/refresh/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/miniproject/domain/refresh/repository/RefreshTokenRepository.java
@@ -1,7 +1,12 @@
 package com.miniproject.domain.refresh.repository;
 
 import com.miniproject.domain.refresh.entity.RefreshToken;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
 
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
@@ -11,5 +16,11 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     RefreshToken findRefreshTokenByMemberEmail(String memberEmail);
 
     void deleteRefreshTokenByMemberEmail(String memberEmail);
+
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.expiryDate < ?1")
+    void deleteAllExpiredSince(LocalDateTime now);
 
 }

--- a/src/main/java/com/miniproject/global/jwt/service/JwtService.java
+++ b/src/main/java/com/miniproject/global/jwt/service/JwtService.java
@@ -71,6 +71,7 @@ public class JwtService {
         JwtPayload jwtPayload = verifyToken(request.refreshToken());
 
         //DB에 저장된 member의 리프레시 토큰을 꺼내옴
+
         var refreshToken = refreshTokenRepository.findRefreshTokenByMemberEmail(jwtPayload.email());
 
         if (refreshToken.getToken() == null) {
@@ -84,7 +85,15 @@ public class JwtService {
 
         //새로운 액세스 토큰 발급
         String refreshedAccessToken = jwtProvider.reCreateToken(jwtPayload, accessExpiration);
+
+        deleteExpiredTokens();
+
         return new JwtPair(refreshedAccessToken, request.refreshToken());
+    }
+
+    public void deleteExpiredTokens() {
+        LocalDateTime now = LocalDateTime.now();
+        refreshTokenRepository.deleteAllExpiredSince(now);
     }
 
     public LoginResponse createLoginResponse(String email) {

--- a/src/main/java/com/miniproject/global/jwt/service/JwtService.java
+++ b/src/main/java/com/miniproject/global/jwt/service/JwtService.java
@@ -93,7 +93,7 @@ public class JwtService {
 
     public void deleteExpiredTokens() {
         LocalDateTime now = LocalDateTime.now();
-        refreshTokenRepository.deleteAllExpiredSince(now);
+        refreshTokenRepository.deleteRefreshTokensByExpiryDateBefore(now);
     }
 
     public LoginResponse createLoginResponse(String email) {

--- a/src/test/java/com/miniproject/domain/accommodation/controller/AccommodationControllerTest.java
+++ b/src/test/java/com/miniproject/domain/accommodation/controller/AccommodationControllerTest.java
@@ -82,7 +82,7 @@ class AccommodationControllerTest {
     @BeforeEach
     public void beforeEach() {
         Member member = Member.builder()
-                .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+                .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         testAuthHeaders = createTestAuthHeader(member.getEmail());
     }
 

--- a/src/test/java/com/miniproject/domain/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/miniproject/domain/basket/controller/BasketControllerTest.java
@@ -72,7 +72,7 @@ public class BasketControllerTest {
     @BeforeEach
     public void beforeEach() {
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         testAuthHeaders = createTestAuthHeader(member.getEmail());
     }
 

--- a/src/test/java/com/miniproject/domain/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/miniproject/domain/basket/service/BasketServiceTest.java
@@ -59,7 +59,7 @@ public class BasketServiceTest {
     public void getBasket_willSuccess() throws Exception {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         Basket basket = new Basket(member, 1L);
         List<Basket> basketList = new ArrayList<>();
         basketList.add(basket);
@@ -105,7 +105,7 @@ public class BasketServiceTest {
         ids.add(1L);
         CheckBasketRequestDto dto = CheckBasketRequestDto.builder().ids(ids).build();
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         Basket basket = new Basket(member, 1L);
         List<Basket> basketList = new ArrayList<>();
         basketList.add(basket);
@@ -125,7 +125,7 @@ public class BasketServiceTest {
     public void registerOrder_willSuccess() throws Exception {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         List<Long> ids = new ArrayList<>();
         ids.add(1L);
         CheckBasketRequestDto dto = CheckBasketRequestDto.builder().ids(ids).build();
@@ -189,7 +189,7 @@ public class BasketServiceTest {
     public void getActivateBasket_willSuccess() throws Exception {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         List<Basket> nowBasket = new ArrayList<>();
         given(basketRepository.findByMember(any(Member.class))).willReturn(nowBasket);
         given(basketRepository.save(any(Basket.class))).willReturn(new Basket(member, 1L));

--- a/src/test/java/com/miniproject/domain/orders/controller/OrdersControllerTest.java
+++ b/src/test/java/com/miniproject/domain/orders/controller/OrdersControllerTest.java
@@ -68,7 +68,7 @@ public class OrdersControllerTest {
     @BeforeEach
     public void beforeEach() {
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         testAuthHeaders = createTestAuthHeader(member.getEmail());
     }
 

--- a/src/test/java/com/miniproject/domain/orders/service/OrderServiceTest.java
+++ b/src/test/java/com/miniproject/domain/orders/service/OrderServiceTest.java
@@ -17,13 +17,20 @@ import com.miniproject.domain.payment.entity.Payment;
 import com.miniproject.domain.payment.repository.PaymentRepository;
 import com.miniproject.domain.room.entity.Room;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.Optional;
+
+import com.miniproject.global.config.CustomHttpHeaders;
+import com.miniproject.global.jwt.JwtPayload;
+import com.miniproject.global.jwt.service.JwtService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 
 @ExtendWith(MockitoExtension.class)
 public class OrderServiceTest {
@@ -35,7 +42,12 @@ public class OrderServiceTest {
     OrdersRepository ordersRepository;
 
     @Mock
+    JwtService jwtService;
+
+    @Mock
     PaymentRepository paymentRepository;
+
+
 
 
     @DisplayName("getOrders()는 주문 객체를 내보낼 수 있다.")
@@ -43,7 +55,7 @@ public class OrderServiceTest {
     public void getOrders_willSuccess() {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
 
         Accommodation accommodation = Accommodation.builder()
             .id(1L)
@@ -76,9 +88,9 @@ public class OrderServiceTest {
     public void getOrders_willFail() {
         //given
         Member member1 = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         Member member2 = Member.builder()
-            .id(2L).nickname("이하").email("kjf@gmail.com").password("ffdfda231321@da").build();
+            .nickname("이하").email("kjf@gmail.com").password("ffdfda231321@da").build();
 
         Accommodation accommodation = Accommodation.builder()
             .id(1L)
@@ -109,7 +121,7 @@ public class OrderServiceTest {
     public void getOrder_willSuccess() {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
 
         Accommodation accommodation = Accommodation.builder()
             .id(1L)
@@ -142,7 +154,7 @@ public class OrderServiceTest {
     public void registerPayment_willSuccess() {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
 
         Accommodation accommodation = Accommodation.builder()
             .id(1L)

--- a/src/test/java/com/miniproject/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/miniproject/domain/payment/controller/PaymentControllerTest.java
@@ -66,7 +66,7 @@ public class PaymentControllerTest {
     @BeforeEach
     public void beforeEach() {
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         testAuthHeaders = createTestAuthHeader(member.getEmail());
     }
 

--- a/src/test/java/com/miniproject/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/miniproject/domain/payment/service/PaymentServiceTest.java
@@ -42,7 +42,7 @@ public class PaymentServiceTest {
     public void getPaymentForException_willSuccess() {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
 
         Orders orders = Orders.builder()
             .id(1L)
@@ -70,7 +70,7 @@ public class PaymentServiceTest {
     public void getPayment_willSuccess() {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
 
         Orders orders = Orders.builder()
             .id(1L)
@@ -100,7 +100,7 @@ public class PaymentServiceTest {
     public void getPayments_willSuccess() {
         //given
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
 
         Orders orders = Orders.builder()
             .id(1L)

--- a/src/test/java/com/miniproject/domain/room/controller/RoomControllerTest.java
+++ b/src/test/java/com/miniproject/domain/room/controller/RoomControllerTest.java
@@ -80,7 +80,7 @@ public class RoomControllerTest {
     @BeforeEach
     public void beforeEach() {
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         testAuthHeaders = createTestAuthHeader(member.getEmail());
     }
 

--- a/src/test/java/com/miniproject/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/com/miniproject/domain/room/service/RoomServiceTest.java
@@ -75,7 +75,7 @@ public class RoomServiceTest {
             .build();
         given(roomRepository.findById(anyLong())).willReturn(Optional.of(room));
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
         Basket basket = new Basket(member, 1L);
         given(basketService.getActivateBasket(any())).willReturn(basket);
         RoomInBasket roomInBasket = RoomInBasket.builder()
@@ -105,7 +105,7 @@ public class RoomServiceTest {
             .checkOutAt(LocalDate.now().withDayOfMonth(30))
             .numberOfGuests(2).build();
         Member member = Member.builder()
-            .id(1L).nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
+            .nickname("하이").email("kj@gmail.com").password("ffdfda231321@da").build();
 
         Accommodation accommodation = Accommodation.builder()
             .id(1L)

--- a/src/test/java/com/miniproject/domain/wish/controller/WishControllerTest.java
+++ b/src/test/java/com/miniproject/domain/wish/controller/WishControllerTest.java
@@ -72,7 +72,7 @@ class WishControllerTest {
     @BeforeEach
     public void init() {
         Member member = Member.builder()
-                .id(1L).nickname("tester").email("tester@gmail.com").password("ffdfda231321@da").build();
+                .nickname("tester").email("tester@gmail.com").password("ffdfda231321@da").build();
         testAuthHeaders = createTestAuthHeader(member.getEmail());
 
         accommodation1 = Accommodation.builder()


### PR DESCRIPTION
# 내용
- 만료된 JWT Refresh를 관리하기 위한 기능을 추가합니다.
- Member Entity에 Basket 연관관계 매핑을 추가합니다.

# 주요 리팩토링
- Refresh 토큰을 통해 AccessToken을 재발급 할 때마다 `RefreshTokenRepository`의 `deleteRefreshTokensByExpiryDateBefore`를 통해 만료된 시간의 RefreshToken을 제거하는 기능, 이에 따른 테스트를 추가합니다.

# 추가적인 내용
- 이외에도 적용하진 않았지만 Spring Batch Job으로 주기적인 관리를 할 수 있을 것 같습니다.